### PR TITLE
Decoder additions

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,7 +9,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = ">= 0.58.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,13 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "simplifile", version = "2.0.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "95219227A43FCFE62C6E494F413A1D56FF953B68FE420698612E3D89A1EFE029" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
+  { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
+  { name = "simplifile", version = "2.2.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C88E0EE2D509F6D86EB55161D631657675AA7684DAB83822F7E59EB93D9A60E3" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = ">= 0.58.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/cymbal.gleam
+++ b/src/cymbal.gleam
@@ -31,8 +31,12 @@ pub fn decode(value: String) -> Result(Yaml, String) {
 fn remove_esc_nl_esc(value: String, acc: String) -> String {
   case value {
     "\\\n" <> rest -> {
-      let rest = string.crop(rest, "\\") |> string.drop_start(1)
-      remove_esc_nl_esc(rest, acc)
+      let rest = string.trim_start(rest)
+      let rest2 = case string.first(rest) {
+        Ok("\\") -> string.drop_start(rest, 1)
+        _ -> rest
+      }
+      remove_esc_nl_esc(rest2, acc)
     }
     "" -> acc
     _ ->
@@ -581,18 +585,14 @@ fn parse_block_scalar(
         Keep -> {
           let #(line_as_string, new_tokens) =
             tokens_to_string_until_newline(tokens, "", indent)
-          let line_as_string = case string.ends_with(line_as_string, "\\\n") {
-            True -> string.drop_end(line_as_string, 2) |> string.append("\\n")
-            False -> line_as_string
-          }
           parse_block_scalar(
             new_tokens,
             value
-              <> line_as_string
-              <> case line_as_string {
+              <> case value {
               "" -> ""
               _ -> "\\n"
-            },
+            }
+              <> line_as_string,
             indent,
             block_type,
           )

--- a/src/cymbal.gleam
+++ b/src/cymbal.gleam
@@ -20,9 +20,27 @@ pub fn encode_without_document_start(doc: Yaml) -> String {
 /// Convert a string into a YAML document.
 ///
 pub fn decode(value: String) -> Result(Yaml, String) {
-  string.split(value, "\n")
+  value
+  |> remove_esc_nl_esc("")
+  |> string.split("\n")
   |> tokenize_lines
   |> parse_tokens
+}
+
+/// Escape (remove) \\\n....\ sequences
+fn remove_esc_nl_esc(value: String, acc: String) -> String {
+  case value {
+    "\\\n" <> rest -> {
+      let rest = string.crop(rest, "\\") |> string.drop_start(1)
+      remove_esc_nl_esc(rest, acc)
+    }
+    "" -> acc
+    _ ->
+      remove_esc_nl_esc(
+        string.drop_start(value, 1),
+        acc <> result.unwrap(string.first(value), ""),
+      )
+  }
 }
 
 import gleam/float
@@ -39,6 +57,8 @@ pub type Token {
   Indent(Int)
   Pipe
   RightArrow
+  CMappingStart
+  CMappingEnd
 }
 
 pub fn en(acc: String, in: Int, doc: Yaml) -> String {
@@ -328,21 +348,17 @@ fn count_leading_spaces(line: String) -> Int {
 }
 
 fn get_tokenized_value_or_block_scalar_indicator(stripped: String) {
-  case
+  let last_char_or_value =
     string.split(stripped, ": ")
     |> list.rest
     |> result.unwrap([])
     |> string.join(": ")
-  {
+
+  case last_char_or_value {
     ">" -> RightArrow
     "|" -> Pipe
-    _ ->
-      Value(
-        string.split(stripped, ": ")
-        |> list.rest
-        |> result.unwrap([])
-        |> string.join(": "),
-      )
+    "{" -> CMappingStart
+    _ -> Value(last_char_or_value)
   }
 }
 
@@ -356,14 +372,14 @@ fn tokenize_sequence_item(stripped: String, indent: Int) {
     True -> [
       Indent(indent),
       Dash,
-      Value(string.drop_left(stripped, 2)),
+      Value(string.drop_start(stripped, 2)),
       Colon,
       Newline,
     ]
     False -> [
       Indent(indent),
       Dash,
-      Value(string.drop_left(stripped, 2)),
+      Value(string.drop_start(stripped, 2)),
       Newline,
     ]
   }
@@ -376,7 +392,7 @@ fn tokenize_sequence_item(stripped: String, indent: Int) {
         string.split(stripped, ": ")
         |> list.first
         |> result.unwrap("")
-        |> string.drop_left(2),
+        |> string.drop_start(2),
       ),
       Colon,
       get_tokenized_value_or_block_scalar_indicator(stripped),
@@ -405,8 +421,8 @@ fn tokenize_key_value_pair(stripped: String, indent: Int) {
       Newline,
     ]
     False ->
-      case string.contains(stripped, ":") {
-        True -> [
+      case string.last(stripped) {
+        Ok(":") -> [
           Indent(indent),
           Key(
             string.split(stripped, ":")
@@ -416,7 +432,8 @@ fn tokenize_key_value_pair(stripped: String, indent: Int) {
           Colon,
           Newline,
         ]
-        False -> [Indent(indent), Value(stripped), Newline]
+        Ok("}") -> [Indent(indent), CMappingEnd, Newline]
+        _ -> [Indent(indent), Value(stripped), Newline]
       }
   }
 }
@@ -428,7 +445,8 @@ pub fn parse_tokens(tokens: List(Token)) -> Result(Yaml, String) {
   }
 
   case result {
-    Ok(#(yaml, _)) -> Ok(yaml)
+    Ok(#(yaml, [])) -> Ok(yaml)
+    Ok(#(_yaml, _rest)) -> Error("Not fully parsed")
     Error(error) -> Error(error)
   }
 }
@@ -458,22 +476,21 @@ fn parse_block_items(
       parse_block_items(
         rest,
         indent,
-        list.append(items, [#(key, parse_value(value))]),
+        list.append(items, [#(string.replace(key, "'", ""), parse_value(value))]),
       )
 
     [Indent(current_indent), Key(key), Colon, Newline, ..rest]
       if current_indent == indent
-    -> {
+    ->
       case parse_block(rest, indent + 1) {
         Ok(#(nested_block, remaining_tokens)) ->
           parse_block_items(
             remaining_tokens,
             indent,
-            list.append(items, [#(key, nested_block)]),
+            list.append(items, [#(string.replace(key, "'", ""), nested_block)]),
           )
         Error(error) -> Error(error)
       }
-    }
 
     // TODO: Make the following two cases into one as only the Fold/Keep changes
     [Indent(current_indent), Key(key), Colon, RightArrow, Newline, ..rest]
@@ -501,6 +518,23 @@ fn parse_block_items(
         list.append(items, [#(key, parse_value(multiline_string))]),
       )
     }
+
+    [Indent(current_indent), Key(key), Colon, CMappingStart, Newline, ..rest]
+      if current_indent == indent
+    -> {
+      case parse_block(rest, indent + 1) {
+        Ok(#(nested_block, remaining_tokens)) ->
+          parse_block_items(
+            remaining_tokens,
+            indent,
+            list.append(items, [#(key, nested_block)]),
+          )
+        Error(error) -> Error(error)
+      }
+    }
+    [Indent(current_indent), CMappingEnd, Newline, ..rest]
+      if current_indent == indent
+    -> parse_block_items(rest, indent, items)
 
     [Indent(current_indent), Dash, Value(_), Newline, ..]
       if current_indent == indent
@@ -547,14 +581,18 @@ fn parse_block_scalar(
         Keep -> {
           let #(line_as_string, new_tokens) =
             tokens_to_string_until_newline(tokens, "", indent)
+          let line_as_string = case string.ends_with(line_as_string, "\\\n") {
+            True -> string.drop_end(line_as_string, 2) |> string.append("\\n")
+            False -> line_as_string
+          }
           parse_block_scalar(
             new_tokens,
             value
-              <> case value {
+              <> line_as_string
+              <> case line_as_string {
               "" -> ""
-              _ -> "\n"
-            }
-              <> line_as_string,
+              _ -> "\\n"
+            },
             indent,
             block_type,
           )
@@ -581,7 +619,7 @@ fn tokens_to_string_until_newline(
     [Dash, ..rest] ->
       tokens_to_string_until_newline(rest, current_value <> "-", indent)
     [Colon, Newline, ..rest] ->
-      tokens_to_string_until_newline(rest, current_value <> ":\n", indent)
+      tokens_to_string_until_newline(rest, current_value <> ":\\n", indent)
     [Colon, ..rest] ->
       tokens_to_string_until_newline(rest, current_value <> ": ", indent)
     [Key(key), ..rest] ->
@@ -594,6 +632,11 @@ fn tokens_to_string_until_newline(
       tokens_to_string_until_newline(rest, current_value <> "| ", indent)
     [RightArrow, ..rest] ->
       tokens_to_string_until_newline(rest, current_value <> ">", indent)
+    [CMappingStart, ..rest] ->
+      tokens_to_string_until_newline(rest, current_value <> "{", indent)
+    [CMappingEnd, ..rest] ->
+      tokens_to_string_until_newline(rest, current_value <> "}", indent)
+
     [Newline, ..rest] -> #(current_value, rest)
     [] -> #(current_value, tokens)
   }
@@ -679,7 +722,7 @@ fn parse_int(value: String) {
 
 fn parse_octal(value: String) {
   case
-    octal_to_decimal(string.drop_left(value, 2)),
+    octal_to_decimal(string.drop_start(value, 2)),
     string.starts_with(value, "0o")
   {
     Ok(decimal), True -> int(decimal)
@@ -689,7 +732,7 @@ fn parse_octal(value: String) {
 
 fn parse_hexadecimal(value: String) {
   case
-    hex_to_decimal(string.drop_left(value, 2)),
+    hex_to_decimal(string.drop_start(value, 2)),
     string.starts_with(value, "0x")
   {
     Ok(decimal), True -> int(decimal)


### PR DESCRIPTION
I had to make some small additions/changes to be able to decode an [OpenAPI yaml spec](https://api.skolverket.se/skolenhetsregistret/skolenhetsregistret_v2_openapi.yaml) and convert it into json.
I am not sure why I had to modify a "\n" string to "\\\n" in some cases. Maybe it is the oas decoder that I use in the next step that is the problem there.
The code for the complete sequence can be found in the [snafe](https://github.com/karlsson/snafe) repository, in the `test/snafe/gen_units.gleam` file.